### PR TITLE
Close #6: help text for variables only in one language possible

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -36,7 +36,7 @@ if (function_exists('XH_wantsPluginAdministration') && XH_wantsPluginAdministrat
         }
 
         // read the stored data, $raw_mpd is re-used in detecting values of former versions
-        $raw_mpd = file_get_contents($pth['folder']['plugins'].'morepagedata/config/config2.php');
+        $raw_mpd = file_get_contents($pth['folder']['content'].'morepagedata.json');
         $mpd = json_decode($raw_mpd,true);
 
         // Plugin main view

--- a/funcs.php
+++ b/funcs.php
@@ -3,7 +3,7 @@
 function mpd_CheckFiles()
 {
     global $pth;
-    $file = $pth['folder']['plugins'].'morepagedata/config/config2.php';
+    $file = $pth['folder']['content'].'morepagedata.json';
 
     if(!is_file($file) || filesize($file)<10) {
         if(!file_put_contents($file, '{"var":[""],"display":[""],"type":[""],"hr":[""],"br":[1],"options":[""],"help":[""],"template":[""]}')) {
@@ -37,7 +37,7 @@ function mpd_receivePostData()
     $newmpd['template']      =isset($_POST['mpd']['template'])? $_POST['mpd']['template']      : array();
 
     // load the old data to check for existing var
-    $mpd = json_decode(file_get_contents($pth['folder']['plugins'].'morepagedata/config/config2.php'),true);
+    $mpd = json_decode(file_get_contents($pth['folder']['content'].'morepagedata.json'),true);
     if($mpd == null) $mpd = array();
 
     // a little clean up
@@ -181,7 +181,7 @@ function mpd_receivePostData()
 
     // SAVE to file
     //==============
-    file_put_contents($pth['folder']['plugins'] . 'morepagedata/config/config2.php',json_encode($newmpd));
+    file_put_contents($pth['folder']['content'].'morepagedata.json',json_encode($newmpd));
 
     return $o;
 }

--- a/index.php
+++ b/index.php
@@ -45,8 +45,8 @@ function getPageDataFields()
 
 
 // Get the field arrays
-$mpd = is_file($pth['folder']['plugins'].'morepagedata/config/config2.php')
-    ? json_decode(file_get_contents($pth['folder']['plugins'].'morepagedata/config/config2.php'),true)
+$mpd = is_file($pth['folder']['content'].'morepagedata.json')
+    ? json_decode(file_get_contents($pth['folder']['content'].'morepagedata.json'),true)
     : array('var'=>array());
 
 // Add used interests to router

--- a/morepagedata_view.php
+++ b/morepagedata_view.php
@@ -16,7 +16,7 @@ if (!defined('CMSIMPLE_XH_VERSION')) {
 function morepagedata_view($page){
 	global $cf, $c, $cl, $h, $hjs, $bjs, $l, $plugin_cf, $plugin_tx, $pth, $sl, $sn, $su, $tx, $u, $pd_router, $txc;
 
-    $filename = $pth['folder']['plugins'].'morepagedata/config/config2.php';
+    $filename = $pth['folder']['content'].'morepagedata.json';
     if (!is_readable($filename) || !is_array($mpd = json_decode(file_get_contents($filename),true))) {
         return '<p>'.$plugin_tx['morepagedata']['pagedata_nothing'].'</p>';
     }


### PR DESCRIPTION
For multilingual sites, it would be nice to have localized display
names.  The simplest solution is to move config2.php to the contents/
folder of CMSimple_XH.  We also rename the file to morepagedata.json.

---

This is obviously a BC break; after updating, users would have to move config2.php to morepagedata.json, possibly having to make copies in the language subfolders of content/. Even worse, admins of multilingual sites who don't need the display name in different languages, would have a maintainence burden.

Actually, the proper solution for this issue appears to be having a single file for all languages with all information except for the display names, and a file with the display names for each language (should probably be configurable to allow for a single file with the display names for all languages).

If we go for this, I'd still prefer to ship it with 1.3.0, not [1.2.3](https://github.com/cmsimple-xh/morepagedata/milestone/3) which is currently scheduled. IMO, postponing these bugfixes to 1.3.0 is fine.